### PR TITLE
fix: use file instead of barrel of ES6 modules

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,0 +1,3 @@
+export * from './client/useEventSource'
+export * from './client/useSubscribe'
+export * from './client/RemixSseProvider'

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,3 +1,0 @@
-export * from './useEventSource';
-export * from './useSubscribe';
-export * from './RemixSseProvider';


### PR DESCRIPTION
* ES6 modules do not allow directory imports without an experimental node setting, so we will just export the client code from a file called "client" instead